### PR TITLE
fix: ダッシュボードタブのダークモード対応

### DIFF
--- a/app/dashboard/dashboard-tabs.tsx
+++ b/app/dashboard/dashboard-tabs.tsx
@@ -84,14 +84,14 @@ export function DashboardTabs({ initialGenres, initialTags, statsData, recentArt
   return (
     <>
       {/* タブナビゲーション */}
-      <div className="flex space-x-1 mb-6 bg-gray-100 p-1 rounded-lg overflow-x-auto scrollbar-hide"
+      <div className="flex space-x-1 mb-6 bg-gray-100 dark:bg-gray-800 p-1 rounded-lg overflow-x-auto scrollbar-hide"
            style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
         <button
           onClick={() => setActiveTab("articles")}
           className={`px-3 sm:px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
             activeTab === "articles"
-              ? "bg-white text-gray-900 shadow-sm"
-              : "text-gray-600 hover:text-gray-900"
+              ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+              : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
           }`}
         >
           記事管理
@@ -100,8 +100,8 @@ export function DashboardTabs({ initialGenres, initialTags, statsData, recentArt
           onClick={() => setActiveTab("genres")}
           className={`px-3 sm:px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
             activeTab === "genres"
-              ? "bg-white text-gray-900 shadow-sm"
-              : "text-gray-600 hover:text-gray-900"
+              ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+              : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
           }`}
         >
           ジャンル管理
@@ -110,8 +110,8 @@ export function DashboardTabs({ initialGenres, initialTags, statsData, recentArt
           onClick={() => setActiveTab("tags")}
           className={`px-3 sm:px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
             activeTab === "tags"
-              ? "bg-white text-gray-900 shadow-sm"
-              : "text-gray-600 hover:text-gray-900"
+              ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+              : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
           }`}
         >
           タグ管理
@@ -120,8 +120,8 @@ export function DashboardTabs({ initialGenres, initialTags, statsData, recentArt
           onClick={() => setActiveTab("stats")}
           className={`px-3 sm:px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
             activeTab === "stats"
-              ? "bg-white text-gray-900 shadow-sm"
-              : "text-gray-600 hover:text-gray-900"
+              ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+              : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
           }`}
         >
           統計情報


### PR DESCRIPTION
## Summary
ダッシュボードページのタブナビゲーションにダークモード対応を追加しました。

## 修正内容

### 🌙 ダークモード対応
- **タブ背景**: `bg-gray-100` → `bg-gray-100 dark:bg-gray-800`
- **アクティブタブ**: `bg-white` → `bg-white dark:bg-gray-700`
- **テキストカラー**: ライト/ダークモード両対応
- **ホバー状態**: 適切なコントラスト確保

### 🎯 改善されたUX
- ダークモードでタブが見やすくなりました
- アクティブタブが明確に識別できます  
- ホバー状態のフィードバックが改善されました

## Before & After

### Before (ダークモード)
- タブが白い背景で気持ち悪い表示
- コントラストが不適切

### After (ダークモード)
- 美しいダークグレーの背景
- 適切なコントラストと視認性

## Test plan
- [x] ライトモードでの表示確認
- [x] ダークモードでの表示確認  
- [x] タブ切り替えの動作確認
- [x] ホバー状態の確認

🤖 Generated with [Claude Code](https://claude.ai/code)